### PR TITLE
Change setupContainer to setupContainers.  Use array of func instead.

### DIFF
--- a/src/ActionExecutor.ts
+++ b/src/ActionExecutor.ts
@@ -76,11 +76,16 @@ export class ActionExecutor {
             });
         }
 
-        // if setup-container callback was set then execute it before controller method execution
-        if (this.builder.options.setupContainer) {
-            const setupContainerResult = this.builder.options.setupContainer(action.container, action);
-            if (setupContainerResult instanceof Promise)
-                return setupContainerResult.then(() => this.step3(action));
+        // if setup-containers callback was set then execute it before controller method execution
+        if (this.builder.options.setupContainers) {
+          const promiseList = [];
+          this.builder.options.setupContainers.forEach((fn) => {
+            const containerResult = fn(action.container, action);
+            if (contanerResult instanceof Promise) {
+              promiseList.push(containerResult);
+            }
+          });
+          Promise.all(promiseList).then(() => this.step3(action));
         }
 
         return this.step3(action);

--- a/src/options/SchemaBuilderOptions.ts
+++ b/src/options/SchemaBuilderOptions.ts
@@ -19,10 +19,10 @@ export interface SchemaBuilderOptions extends GraphModule {
     authorizationChecker?: (roles: any[], action: Action) => Promise<boolean>|boolean;
 
     /**
-     * Can be used to setup container on each user request.
+     * Can be used to setup containers on each user request.
      * For example, you can setup a currently authorized user and store it in the container.
      */
-    setupContainer?: (container: ContainerInstance, action: Action) => Promise<any>|any;
+    setupContainers?: Array<(container: ContainerInstance, action: Action) => Promise<any>|any>;
 
     /**
      * Setups AsyncIterator to use it for subscriptions.


### PR DESCRIPTION
Provide option to add multi containers for the user to setup instead of one.
A good example is, we want to grab current user(TS/sample10) and use pubsub(TS/sample11).
