### PR TITLE
Use ConnectionManager to connect to database in SchemaBuilder

### DIFF
--- a/src/SchemaBuilder.ts
+++ b/src/SchemaBuilder.ts
@@ -4,7 +4,7 @@ import {getMetadataArgsStorage} from "./index";
 import {
     Connection,
     ConnectionOptionsReader,
-    createConnection,
+    getConnectionManager,
     getMetadataArgsStorage as getTypeORMMetadataArgsStorage
 } from "typeorm";
 import {GraphQLScalarType, GraphQLSchema, Kind} from "graphql";
@@ -190,7 +190,7 @@ export class SchemaBuilder {
                 }
                 // todo: what about migrations ?
             });
-            return createConnection();
+            return getConnectionManager().create(options).connect();
         }
     }
 


### PR DESCRIPTION
I tried the custom connection options but found out I missed an important piece - tell typeorm to use the options :)

`createConnection` will not use the custom connection options, we need to use `getConnectionManager` to create the custom connection.